### PR TITLE
[actions] Board github actions for Java CI, SonarCloud, and Sonatype …

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+#
+#    Copyright 2016-2020 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+name: Java CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        java: [8, 11, 15, 16-ea]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Test with Maven
+        run: ./mvnw test -B -D"license.skip=true"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,41 @@
+#
+#    Copyright 2016-2020 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    if: github.repository_owner == 'mybatis'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Analyze with SonarCloud
+        run: ./mvnw verify sonar:sonar -B -Dsonar.projectKey=mybatis_cdi -Dsonar.organization=mybatis -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dlicense.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -1,0 +1,38 @@
+#
+#    Copyright 2016-2020 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+name: Sonatype
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    if: github.repository_owner == 'mybatis'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Deploy to Sonatype
+        run: ./mvnw deploy -DskipTests -B --settings ./.mvn/settings.xml -Dlicense.skip=true
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2016-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<extensions>
+    <extension>
+      <groupId>fr.jcgay.maven</groupId>
+      <artifactId>maven-profiler</artifactId>
+      <version>3.0</version>
+    </extension>
+</extensions>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2016 the original author or authors.
+       Copyright 2016-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,8 +26,11 @@
     </server>
     <server>
       <id>gh-pages</id>
-      <username>git</username>
-      <password>${env.CI_SITE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>github</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.GITHUB_TOKEN}</password>
     </server>
   </servers>
 </settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
 
 jdk:
-  - openjdk16
-  - openjdk15
-  - openjdk11
   - openjdk8
 
 after_success:

--- a/travis/after_success.sh
+++ b/travis/after_success.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#    Copyright 2016-2018 the original author or authors.
+#    Copyright 2016-2020 the original author or authors.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -16,47 +16,39 @@
 #
 
 
-# Get Project Repo
-mybatis_repo=$(git config --get remote.origin.url 2>&1)
-echo "Repo detected: ${mybatis_repo}"
-
 # Get Commit Message
 commit_message=$(git log --format=%B -n 1)
 echo "Current commit detected: ${commit_message}"
-
-# Get the Java version.
-# Java 1.5 will give 15.
-# Java 1.6 will give 16.
-# Java 1.7 will give 17.
-# Java 1.8 will give 18.
-VER=`java -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q'`
-echo "Java detected: ${VER}"
 
 # We build for several JDKs on Travis.
 # Some actions, like analyzing the code (Coveralls) and uploading
 # artifacts on a Maven repository, should only be made for one version.
  
-# If the version is 1.6, then perform the following actions.
-# 1. Upload artifacts to Sonatype.
-# 2. Use -q option to only display Maven errors and warnings.
-# 3. Use --settings to force the usage of our "settings.xml" file.
-
-# If the version is 1.7, then perform the following actions.
+# If the version is 1.8, then perform the following actions.
 # 1. Notify Coveralls.
-# 2. Deploy site
-# 3. Use -q option to only display Maven errors and warnings.
+# 2. Deploy site (disabled as solution not complete).
 
-if [ "$mybatis_repo" == "https://github.com/mybatis/caffeine-cache.git" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [[ "$commit_message" != *"[maven-release-plugin]"* ]]; then
-  if [ $VER == "16" ]; then
-    mvn clean deploy -q --settings ./travis/settings.xml
-    echo -e "Successfully deployed SNAPSHOT artifacts to Sonatype under Travis job ${TRAVIS_JOB_NUMBER}"
-  elif [ $VER == "17" ]; then
-    mvn clean test jacoco:report coveralls:report -q
+# Paramters
+# 1. Use -q option to only display Maven errors and warnings.
+# 2. Use --settings to force the usage of our "settings.xml" file.
+
+if [ $TRAVIS_REPO_SLUG == "mybatis/caffeine-cache" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [[ "$commit_message" != *"[maven-release-plugin]"* ]]; then
+
+  if [ ${TRAVIS_JDK_VERSION} == "openjdk8" ]; then
+
+    # Deploy to coveralls
+    ./mvnw clean test jacoco:report coveralls:report -q --settings ./mvn/settings.xml
     echo -e "Successfully ran coveralls under Travis job ${TRAVIS_JOB_NUMBER}"
-	# various issues exist currently in building this so comment for now
-	# mvn site site:deploy -q
-	# echo -e "Successfully deploy site under Travis job ${TRAVIS_JOB_NUMBER}"
+
+    # Deploy to site
+    # Cannot currently run site this way
+    # ./mvnw site site:deploy -q --settings ./mvn/settings.xml
+    # echo -e "Successfully deploy site under Travis job ${TRAVIS_JOB_NUMBER}"
+  else
+    echo "Java Version does not support additonal activity for travis CI"
   fi
 else
+  echo "Travis Pull Request: $TRAVIS_PULL_REQUEST"
+  echo "Travis Branch: $TRAVIS_BRANCH"
   echo "Travis build skipped"
 fi


### PR DESCRIPTION
…with travis cleanup

- travis work includes: drop jdk 11-16 as covered under actions, cleanup travis file to match usage of slugs, remove sonatype as covered under actions.

- maven work includes: move settings.xml into .mvn folder for clarity

- actions work includes: Board Java CI, SonarCloud, and Sonatype as initial baseline.