### PR TITLE
[fix] Do not allow null key or null value to be added to cache fixes #152

### DIFF
--- a/src/main/java/org/mybatis/caches/caffeine/CaffeineCache.java
+++ b/src/main/java/org/mybatis/caches/caffeine/CaffeineCache.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2022 the original author or authors.
+ *    Copyright 2016-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,10 @@ public final class CaffeineCache implements Cache {
 
   @Override
   public void putObject(Object key, Object value) {
-    this.cache.put(key, value);
+    // Do not allow null values to be cached as not allowed in caffeine cache
+    if (key != null && value != null) {
+      this.cache.put(key, value);
+    }
   }
 
   @Override


### PR DESCRIPTION
fixes #152

caffeine will throw null pointer exception so do not add null types