### PR TITLE
[GHA] Drop jdk 22, add 23 GA, add 24-ea/25-ea

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         cache: [maven]
         distribution: [temurin]
-        java: [17, 21, 22, 23-ea]
+        java: [17, 21, 23, 24-ea, 25-ea]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
jdk 25 will work or should work once parent is applied.  Will address any issue then in regards.